### PR TITLE
interpreters now work

### DIFF
--- a/languages/calculator.expressions/calculator.expressions.mpl
+++ b/languages/calculator.expressions/calculator.expressions.mpl
@@ -51,6 +51,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)</dependency>
     <dependency reexport="false">c3df5888-832d-4c04-9f30-4037e590699c(calculator.workbook)</dependency>
+    <dependency reexport="false">47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />
@@ -97,12 +98,17 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="d02a2dd0-94e2-4d3e-89d5-079aaade8f38(calculator.expressions)" version="0" />
     <module reference="c3df5888-832d-4c04-9f30-4037e590699c(calculator.workbook)" version="0" />
+    <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
     <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
   <extendedLanguages />
 </language>

--- a/languages/calculator.expressions/models/behavior.mps
+++ b/languages/calculator.expressions/models/behavior.mps
@@ -9,6 +9,7 @@
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="4m13" ref="r:f49b0914-f58d-4bc8-b1b1-c4eaedf6eab1(calculator.workbook.structure)" />
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" />
+    <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" />
     <import index="vlzc" ref="r:bf59596c-a8b4-4e3c-a9cc-4920156b8c78(calculator.expressions.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" implicit="true" />
@@ -54,9 +55,6 @@
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
-      </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
-        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
@@ -343,6 +341,7 @@
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
+      <node concept="17QB3L" id="KLPc7X$2NR" role="3clF45" />
       <node concept="3clFbS" id="KLPc7XzTWY" role="3clF47">
         <node concept="SfApY" id="5XTTgW$WlZQ" role="3cqZAp">
           <node concept="3clFbS" id="5XTTgW$WlZS" role="SfCbr">
@@ -362,44 +361,6 @@
                   </node>
                   <node concept="3uibUv" id="5XTTgW$XpgW" role="10QFUM">
                     <ref role="3uigEE" to="2ahs:2yaxsm5jIAm" resolve="CombinedInterpreter" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5XTTgW$Xs_s" role="3cqZAp">
-              <node concept="2OqwBi" id="5XTTgW$Xs_p" role="3clFbG">
-                <node concept="10M0yZ" id="5XTTgW$Xs_q" role="2Oq$k0">
-                  <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                </node>
-                <node concept="liA8E" id="5XTTgW$Xs_r" role="2OqNvi">
-                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.Object):void" resolve="println" />
-                  <node concept="2OqwBi" id="5XTTgW$XqFs" role="37wK5m">
-                    <node concept="37vLTw" id="5XTTgW$Xq46" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5XTTgW$W3yW" resolve="interpreter" />
-                    </node>
-                    <node concept="liA8E" id="5XTTgW$XrIR" role="2OqNvi">
-                      <ref role="37wK5l" to="2ahs:6ENu_m7tE9k" resolve="listEvaluators" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="5XTTgW$X873" role="3cqZAp">
-              <node concept="2OqwBi" id="5XTTgW$X870" role="3clFbG">
-                <node concept="10M0yZ" id="5XTTgW$X871" role="2Oq$k0">
-                  <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                </node>
-                <node concept="liA8E" id="5XTTgW$X872" role="2OqNvi">
-                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String):void" resolve="println" />
-                  <node concept="3cpWs3" id="5XTTgW$X9_t" role="37wK5m">
-                    <node concept="Xl_RD" id="5XTTgW$X9_z" role="3uHU7B">
-                      <property role="Xl_RC" value="I: " />
-                    </node>
-                    <node concept="37vLTw" id="5XTTgW$X8Ca" role="3uHU7w">
-                      <ref role="3cqZAo" node="5XTTgW$W3yW" resolve="interpreter" />
-                    </node>
                   </node>
                 </node>
               </node>
@@ -488,7 +449,6 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="KLPc7XzSBW" role="1B3o_S" />
-      <node concept="17QB3L" id="KLPc7X$2NR" role="3clF45" />
       <node concept="ffn8J" id="KLPc7X$bnN" role="3clF46">
         <property role="TrG5h" value="n" />
         <ref role="ffrpq" to="6bz1:6yt8uwrpTKS" resolve="node" />

--- a/languages/calculator.workbook/models/behavior.mps
+++ b/languages/calculator.workbook/models/behavior.mps
@@ -5,7 +5,78 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="1" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="763u" ref="r:e46c3f39-5a0d-4dd9-b307-7851234a0d1b(calculator.expressions.behavior)" />
+    <import index="4m13" ref="r:f49b0914-f58d-4bc8-b1b1-c4eaedf6eab1(calculator.workbook.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz" />
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="Af$HzLtZoz">
+    <ref role="13h7C2" to="4m13:4LThsz0VJ5_" resolve="VariableDeclaration" />
+    <node concept="13i0hz" id="Af$HzLtZoI" role="13h7CS">
+      <property role="TrG5h" value="evaluate" />
+      <node concept="3Tm1VV" id="Af$HzLtZoJ" role="1B3o_S" />
+      <node concept="3uibUv" id="Af$HzLtZp9" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="3clFbS" id="Af$HzLtZoL" role="3clF47">
+        <node concept="3clFbF" id="Af$HzLtZpA" role="3cqZAp">
+          <node concept="2YIFZM" id="Af$HzLu1a_" role="3clFbG">
+            <ref role="37wK5l" to="763u:KLPc7XzTWV" resolve="callInterpreterExplicitly" />
+            <ref role="1Pybhc" to="763u:KLPc7XzLx7" resolve="CombinedInterpreterUtil" />
+            <node concept="13iPFW" id="Af$HzLu1bF" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="Af$HzLtZo$" role="13h7CW">
+      <node concept="3clFbS" id="Af$HzLtZo_" role="2VODD2" />
+    </node>
+  </node>
 </model>
 

--- a/languages/calculator.workbook/models/editor.mps
+++ b/languages/calculator.workbook/models/editor.mps
@@ -13,6 +13,7 @@
     <import index="763u" ref="r:e46c3f39-5a0d-4dd9-b307-7851234a0d1b(calculator.expressions.behavior)" />
     <import index="4m13" ref="r:f49b0914-f58d-4bc8-b1b1-c4eaedf6eab1(calculator.workbook.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="geo5" ref="r:9f6e281d-8dd7-47ed-b3de-84a3c5bc1616(calculator.workbook.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -78,14 +79,18 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
-        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
@@ -93,9 +98,13 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
-        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
     </language>
     <language id="a0ab8c10-c118-4755-ba27-3853435cf524" name="de.itemis.mps.tooltips">
@@ -110,6 +119,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -161,17 +171,22 @@
   <node concept="24kQdi" id="4LThsz0VJ5C">
     <ref role="1XX52x" to="4m13:4LThsz0VJ5_" resolve="VariableDeclaration" />
     <node concept="3EZMnI" id="4LThsz0VJ8h" role="2wV5jI">
-      <node concept="2iRfu4" id="4LThsz0VJ8i" role="2iSdaV" />
       <node concept="1j7BWu" id="KLPc7XyYBf" role="3EZMnx">
         <node concept="1HlG4h" id="KLPc7Xz1l9" role="1j7ClA">
           <node concept="1HfYo3" id="KLPc7Xz1lb" role="1HlULh">
             <node concept="3TQlhw" id="KLPc7Xz1ld" role="1Hhtcw">
               <node concept="3clFbS" id="KLPc7Xz1lf" role="2VODD2">
-                <node concept="3clFbF" id="KLPc7X$0BH" role="3cqZAp">
-                  <node concept="2YIFZM" id="KLPc7X$1lo" role="3clFbG">
-                    <ref role="37wK5l" to="763u:KLPc7XzTWV" resolve="callInterpreterExplicitly" />
-                    <ref role="1Pybhc" to="763u:KLPc7XzLx7" resolve="CombinedInterpreterUtil" />
-                    <node concept="pncrf" id="KLPc7X$9Th" role="37wK5m" />
+                <node concept="3clFbF" id="Af$HzLD6rY" role="3cqZAp">
+                  <node concept="3cpWs3" id="Af$HzLD7DR" role="3clFbG">
+                    <node concept="Xl_RD" id="Af$HzLD7DX" role="3uHU7w">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                    <node concept="2OqwBi" id="Af$HzLD6Er" role="3uHU7B">
+                      <node concept="pncrf" id="Af$HzLD6rU" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="Af$HzLD7c8" role="2OqNvi">
+                        <ref role="37wK5l" to="geo5:Af$HzLtZoI" resolve="evaluate" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -182,6 +197,7 @@
           <property role="3F0ifm" value="var" />
         </node>
       </node>
+      <node concept="2iRfu4" id="4LThsz0VJ8i" role="2iSdaV" />
       <node concept="3F0A7n" id="4LThsz0VJ8I" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>

--- a/solutions/calculator.expressions.interpreter/models/plugin.mps
+++ b/solutions/calculator.expressions.interpreter/models/plugin.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:2be2085c-018d-4959-83b1-098878a998bb(calculator.expressions.interpreter.interpreter)">
+<model ref="r:2be2085c-018d-4959-83b1-098878a998bb(calculator.expressions.interpreter.plugin)">
   <persistence version="9" />
   <languages>
     <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="0" />

--- a/solutions/calculator.workbook.interpreter/models/plugin.mps
+++ b/solutions/calculator.workbook.interpreter/models/plugin.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:c6a1f1cc-d266-4635-91d5-fe1707ae288d(calculator.workbook.interpreter.interpreter)">
+<model ref="r:c6a1f1cc-d266-4635-91d5-fe1707ae288d(calculator.workbook.interpreter.plugin)">
   <persistence version="9" />
   <languages>
     <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="0" />


### PR DESCRIPTION
unfortunately MPS has a design flaw which requires models that should be loaded in MPS to be called "plugin".
We called our interpreter model "interpreter" which meant that the classloader could not see the generated interpreter classes.